### PR TITLE
Add instance type to launch template

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -453,9 +453,11 @@ resource "aws_eks_node_group" "this" {
   }
 
   lifecycle {
-    create_before_destroy = true
     ignore_changes = [
+      scaling_config[0].max_size,
+      scaling_config[0].min_size,
       scaling_config[0].desired_size,
+      taint,
     ]
   }
 

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -457,7 +457,6 @@ resource "aws_eks_node_group" "this" {
       scaling_config[0].max_size,
       scaling_config[0].min_size,
       scaling_config[0].desired_size,
-      taint,
     ]
   }
 

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -203,7 +203,7 @@ resource "aws_launch_template" "this" {
   }
 
   # # Set on node group instead
-  # instance_type = var.launch_template_instance_type
+  instance_type = var.launch_template_instance_type
   kernel_id = var.kernel_id
   key_name  = var.key_name
 
@@ -406,7 +406,7 @@ resource "aws_eks_node_group" "this" {
   capacity_type        = var.capacity_type
   disk_size            = var.use_custom_launch_template ? null : var.disk_size # if using a custom LT, set disk size on custom LT or else it will error here
   force_update_version = var.force_update_version
-  instance_types       = var.instance_types
+  instance_types       = var.launch_template_instance_type != null ? null : var.instance_types
   labels               = var.labels
 
   dynamic "launch_template" {

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -251,6 +251,12 @@ variable "instance_market_options" {
   default     = {}
 }
 
+variable "launch_template_instance_type" {
+  description = "The instance type when set on the launch template. Conflicts with \"instance_types\""
+  type        = string
+  default     = null
+}
+
 variable "maintenance_options" {
   description = "The maintenance options for the instance"
   type        = any

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -320,6 +320,7 @@ module "eks_managed_node_group" {
   disk_size            = try(each.value.disk_size, var.eks_managed_node_group_defaults.disk_size, null)
   force_update_version = try(each.value.force_update_version, var.eks_managed_node_group_defaults.force_update_version, null)
   instance_types       = try(each.value.instance_types, var.eks_managed_node_group_defaults.instance_types, null)
+  launch_template_instance_type  = try(each.value.launch_template_instance_type, var.eks_managed_node_group_defaults.launch_template_instance_type, null)
   labels               = try(each.value.labels, var.eks_managed_node_group_defaults.labels, null)
 
   remote_access = try(each.value.remote_access, var.eks_managed_node_group_defaults.remote_access, {})


### PR DESCRIPTION
Add instance type to launch template so that can be updated without destroying the node group.  Also do not create before destroy since we are not using name prefixes.